### PR TITLE
zip upload: encode any string to ascii that could contain non-ascii, before print

### DIFF
--- a/imagestore/models/upload.py
+++ b/imagestore/models/upload.py
@@ -36,7 +36,7 @@ def process_zipfile(uploaded_album):
         for filename in sorted(zip.namelist()):
             if filename.startswith('__'):  # do not process meta files
                 continue
-            print filename
+            print filename.encode('ascii', errors='replace')
             data = zip.read(filename)
             if len(data):
                 try:


### PR DESCRIPTION
The Linux terminal is by default an ascii device. So printing unicode raises a unicode exception. The flow of the code here is fine -- except for the print. 

So I've left the print in place (it would be better to use python logging, but I'm not going to get religious), and added the essential encode. The errors='replace' kwarg is needed to ensure that 'something' is printed instead of non-printable characters. By default this is a normal ascii '?'.
