### PR TITLE
Album uploads don't work with Amazon's S3 storage (issue #33)

### DIFF
--- a/imagestore/models/upload.py
+++ b/imagestore/models/upload.py
@@ -11,6 +11,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 try:
     import Image as PILImage
 except ImportError:
@@ -22,9 +23,9 @@ TEMP_DIR = getattr(settings, 'TEMP_DIR', 'temp/')
 
 
 def process_zipfile(uploaded_album):
-    if os.path.isfile(uploaded_album.zip_file.path):
+    if default_storage.exists(uploaded_album.zip_file.name):
         # TODO: implement try-except here
-        zip = zipfile.ZipFile(uploaded_album.zip_file.path)
+        zip = zipfile.ZipFile(uploaded_album.zip_file)
         bad_file = zip.testzip()
         if bad_file:
             raise Exception('"%s" in the .zip archive is corrupt.' % bad_file)
@@ -107,6 +108,6 @@ class AlbumUpload(models.Model):
         upload_processor(self)
 
     def delete(self, *args, **kwargs):
-        storage, path = self.zip_file.storage, self.zip_file.path
+        storage, path = self.zip_file.storage, self.zip_file.name
         super(AlbumUpload, self).delete(*args, **kwargs)
         storage.delete(path)


### PR DESCRIPTION
trying to access the file's path won't work with remote storage providers, giving me this exception:

```
Request Method: POST
Request URL: http://localhost:8000/admin/imagestore/albumupload/add/

Django Version: 1.6.5
Python Version: 2.7.5
Installed Applications:
('djangocms_admin_style',
 'djangocms_text_ckeditor',
 'django.contrib.auth',
 'django.contrib.contenttypes',
 'django.contrib.sessions',
 'django.contrib.admin',
 'django.contrib.sites',
 'django.contrib.sitemaps',
 'django.contrib.staticfiles',
 'django.contrib.messages',
 'cms',
 'mptt',
 'menus',
 'south',
 'sekizai',
 'djangocms_style',
 'djangocms_column',
 'djangocms_file',
 'djangocms_googlemap',
 'djangocms_inherit',
 'djangocms_link',
 'djangocms_picture',
 'reversion',
 'storages',
 'imagestore',
 'imagestore.imagestore_cms',
 'sorl.thumbnail',
 'tagging')
Installed Middleware:
('django.middleware.cache.UpdateCacheMiddleware',
 'django.contrib.sessions.middleware.SessionMiddleware',
 'django.middleware.csrf.CsrfViewMiddleware',
 'django.contrib.auth.middleware.AuthenticationMiddleware',
 'django.contrib.messages.middleware.MessageMiddleware',
 'django.middleware.locale.LocaleMiddleware',
 'django.middleware.doc.XViewMiddleware',
 'django.middleware.common.CommonMiddleware',
 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 'cms.middleware.user.CurrentUserMiddleware',
 'cms.middleware.page.CurrentPageMiddleware',
 'cms.middleware.toolbar.ToolbarMiddleware',
 'cms.middleware.language.LanguageCookieMiddleware')


Traceback:
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  112.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/django/contrib/admin/options.py" in wrapper
  432.                 return self.admin_site.admin_view(view)(*args, **kwargs)
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  99.                     response = view_func(request, *args, **kwargs)
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/django/views/decorators/cache.py" in _wrapped_view_func
  52.         response = view_func(request, *args, **kwargs)
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/django/contrib/admin/sites.py" in inner
  198.             return view(request, *args, **kwargs)
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapper
  29.             return bound_func(*args, **kwargs)
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/django/utils/decorators.py" in _wrapped_view
  99.                     response = view_func(request, *args, **kwargs)
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/django/utils/decorators.py" in bound_func
  25.                 return func(self, *args2, **kwargs2)
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/django/db/transaction.py" in inner
  371.                 return func(*args, **kwargs)
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/django/contrib/admin/options.py" in add_view
  1131.                 self.save_model(request, new_object, form, False)
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/django/contrib/admin/options.py" in save_model
  860.         obj.save()
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/imagestore/models/upload.py" in save
  107.         upload_processor(self)
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/imagestore/models/upload.py" in process_zipfile
  25.     if os.path.isfile(uploaded_album.zip_file.path):
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/django/db/models/fields/files.py" in _get_path
  59.         return self.storage.path(self.name)
File "/Users/roberkules/dev/me/portal/lib/python2.7/site-packages/django/core/files/storage.py" in path
  86.         raise NotImplementedError("This backend doesn't support absolute paths.")

Exception Type: NotImplementedError at /admin/imagestore/albumupload/add/
Exception Value: This backend doesn't support absolute paths.
```

updated `/models/upload.py`:

did 2 brief tests:
- standard storage provider (local filesystem)
- django-storages S3 provider

worked in both cases, but I'm not too familiar with django, so I'm not sure if this would break anything else?!
