### PR TITLE
imported function include in imagestore_cms/urls

### DIFF
--- a/imagestore/imagestore_cms/urls.py
+++ b/imagestore/imagestore_cms/urls.py
@@ -4,10 +4,10 @@
 __author__ = 'zeus'
 
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import patterns, url, include
 except ImportError:
-    from django.conf.urls.defaults import patterns, url
-    
+    from django.conf.urls.defaults import patterns, url, include
+
 from imagestore.views import AlbumListView
 
 urlpatterns = patterns('',


### PR DESCRIPTION
Included function include() in imagestore_cms/urls.
This fixed the error: "NameError: name 'include' is not defined"
