### PR TITLE
Fix migrations missing brief

### DIFF
--- a/imagestore/migrations/0001_initial.py
+++ b/imagestore/migrations/0001_initial.py
@@ -24,7 +24,6 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=100, verbose_name='Name')),
-                ('brief', models.CharField(default='', help_text='Short description', max_length=255, verbose_name='Brief', blank=True)),
                 ('created', models.DateTimeField(auto_now_add=True, verbose_name='Created')),
                 ('updated', models.DateTimeField(auto_now=True, verbose_name='Updated')),
                 ('is_public', models.BooleanField(default=True, verbose_name='Is public')),

--- a/imagestore/migrations/0002_album_brief.py
+++ b/imagestore/migrations/0002_album_brief.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('imagestore', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='album',
+            name='brief',
+            field=models.CharField(default='', help_text='Short description', max_length=255, verbose_name='Brief', blank=True),
+        ),
+    ]


### PR DESCRIPTION
Imagestore 2.7.6 did not have a 'brief' field on Album. When the initial migration for Django 1.7 was created it was assumed that users were using Imagestore versions that already had that field.

With the new migration, when moving to Django 1.7 from Imagestore 2.7.6 you must fake the initial migration, which now does not contain the brief field, and then migrate the second migration.